### PR TITLE
Improve support for camel cased test names

### DIFF
--- a/src/Printer.php
+++ b/src/Printer.php
@@ -110,7 +110,7 @@ class Printer extends PHPUnit_TextUI_ResultPrinter
         $this->testRow = sprintf(
             "%s: %s (%s ms)\n",
             $className,
-            ucfirst(str_replace('_', ' ', $methodName)),
+            preg_replace('/(?<=\\w)(?=[A-Z])/', ' $1', ucfirst(str_replace('_', ' ', $methodName))),
             $testDuration > 500 ? "\e[33m{$testDuration}\e[0m" : $testDuration
         );
     }


### PR DESCRIPTION
This PR attempts to add support for test names written in camel case (i.e. `testItDoesThis`) and allows them to be space separated in output like the snake case variants.

There was no test suite and if it's okay with you + I have time later I'd be happy to help set one up. Meanwhile, the single line of code outputs:

```
>>> preg_replace('/(?<=\\w)(?=[A-Z])/', ' $1', ucfirst(str_replace('_', ' ', 'TestItDoesThis')));
=> "Test It Does This"
>>> preg_replace('/(?<=\\w)(?=[A-Z])/', ' $1', ucfirst(str_replace('_', ' ', 'TestIt_Does_This')));
=> "Test It Does This"
>>> preg_replace('/(?<=\\w)(?=[A-Z])/', ' $1', ucfirst(str_replace('_', ' ', 'TestIt_does_this')));
=> "Test It does this"
```

Please let me know if there's anything you'd like me to change. Thanks for the great lib!