### PR TITLE
Replace with symbols only if colors flag is set

### DIFF
--- a/src/Printer.php
+++ b/src/Printer.php
@@ -210,7 +210,7 @@ class Printer extends ResultPrinter
      */
     protected function hasReplacementSymbol($progress)
     {
-        return in_array($progress, array_keys(static::$symbols));
+        return $this->colors && in_array($progress, array_keys(static::$symbols));
     }
 
     /**


### PR DESCRIPTION
I made this change so it's works with the Windows cmd line. Works for me however not sure if color capability is the same as the capability of displaying those symbols.